### PR TITLE
pkg-config: reorder, first share, then lib

### DIFF
--- a/src/ocb_stubblr.ml
+++ b/src/ocb_stubblr.ml
@@ -41,7 +41,8 @@ module Pkg_config = struct
   let path () =
     let opam = Lazy.force opam_prefix
     and rest = try [Sys.getenv var] with Not_found -> [] in
-    opam/"lib"/"pkgconfig" :: opam/"share"/"pkgconfig" :: rest
+    (* the order matters (at least for old (0.24, ubuntu 14.04) pkgconfig *)
+    opam/"share"/"pkgconfig" :: opam/"lib"/"pkgconfig" :: rest
       |> String.concat ~sep:":"
 
   let run ~flags package =


### PR DESCRIPTION
same as https://github.com/mirage/mirage/pull/676 -- otherwise pkg-config on ubuntu 14.04 is unhappy with our current setup