### PR TITLE
warn and ignore failed `opam config var prefix`

### DIFF
--- a/src/ocb_stubblr.ml
+++ b/src/ocb_stubblr.ml
@@ -12,6 +12,10 @@ let (>>=) a b = match a with Some x -> b x | _ -> None
 let error_msgf fmt =
   Format.ksprintf (fun str -> raise (Failure str)) ("Ocb_stubblr: " ^^ fmt)
 
+let warn_msgf fmt =
+  let k str = Format.printf "%s\n%!" str in
+  Format.ksprintf k ("Ocb_stubblr: " ^^ fmt)
+
 let error_exit_msgf fmt =
   let k str = Format.printf "%s\n%!" str; exit 1 in
   Format.ksprintf k ("Ocb_stubblr: " ^^ fmt)
@@ -31,18 +35,20 @@ module Pkg_config = struct
 
   (* XXX Would be nice to move pkg-config results to a build artefact. *)
 
-  let opam_prefix =
-    let cmd = "opam config var prefix" in
-    lazy ( try run_and_read cmd with Failure _ ->
-            error_msgf "error running opam")
-
   let var = "PKG_CONFIG_PATH"
+
+  let opam_prefix : string option Lazy.t =
+    let cmd = "opam config var prefix" in
+    lazy ( try Some (run_and_read cmd) with Failure _ ->
+      warn_msgf "error detecting opam prefix; not including it in $%s" var; None)
 
   let path () =
     let opam = Lazy.force opam_prefix
-    and rest = try [Sys.getenv var] with Not_found -> [] in
-    opam/"lib"/"pkgconfig" :: opam/"share"/"pkgconfig" :: rest
-      |> String.concat ~sep:":"
+    and system = try [Sys.getenv var] with Not_found -> [] in
+    (match opam with
+      | None -> system
+      | Some opam -> opam/"lib"/"pkgconfig" :: opam/"share"/"pkgconfig" :: system
+    ) |> String.concat ~sep:":"
 
   let run ~flags package =
     let cmd = strf "%s=%s pkg-config %s %s 2>/dev/null"


### PR DESCRIPTION
I maintain [opam2nix](https://github.com/timbertson/opam2nix-packages), which allows building (many) opam packages inside [nix](http://nixos.org/). Unfortunately, users of ocb-stubblr won't compile in this environment, since there is no `opam` binary.

This PR turns failure to run `opam config var prefix` into a warning instead of a failure. e.g:

```
utop # Ocb_stubblr.Pkg_config.run "something";;
sh: opam: command not found                                                                                                                                                                                        Ocb_stubblr: error detecting opam prefix; not including it in $PKG_CONFIG_PATH                                                                                                                                     - : [ `Nonexistent | `Res of string ] = `Nonexistent                                                                                                                                                               
```

In the case of `opam2nix`, ignoring this error is fine since `$PKG_CONFIG_PATH` will be set up appropriately for all dependencies (including depexts). Ignoring the error could mask issues with this code in the future, but I'm hoping the warning will be enough to diagnose such issues.