### PR TITLE
Fix ocb-stubblr inside opam 2 sandbox

### DIFF
--- a/src/ocb_stubblr.ml
+++ b/src/ocb_stubblr.ml
@@ -31,10 +31,14 @@ module Pkg_config = struct
 
   (* XXX Would be nice to move pkg-config results to a build artefact. *)
 
-  let opam_prefix =
+  let opam_prefix_cmd =
     let cmd = "opam config var prefix" in
     lazy ( try run_and_read cmd with Failure _ ->
             error_msgf "error running opam")
+
+  let opam_prefix =
+    lazy (try Sys.getenv "OPAM_SWITCH_PREFIX"
+          with Not_found -> Lazy.force opam_prefix_cmd)
 
   let var = "PKG_CONFIG_PATH"
 


### PR DESCRIPTION
opam 2's sandbox doesn't always expose the mount point of the opam root (it limits the sandbox to the switch root) which means that `opam config var prefix` doesn't necessarily work (see https://github.com/ocaml/opam/issues/3434 and https://github.com/ocaml/opam/issues/3438).

As noted in https://github.com/ocaml/opam/issues/3434#issuecomment-400249067, this PR uses `OPAM_SWITCH_PREFIX` in preference to running `opam config var prefix`.